### PR TITLE
fix article links colour on dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -29,14 +29,6 @@ html {
 	--border-light: var(--gray-4);
 }
 
-a:hover {
-	color: #62629d;
-}
-
-a:visited {
-	color: #6464e2;
-}
-
 :root {
 	color-scheme: dark;
 
@@ -88,7 +80,7 @@ a:visited {
 		color: #000;
 	}
 	.post a {
-		color: #fff;
+		color: var(--text-1-dark);
 	}
 }
 
@@ -104,6 +96,9 @@ a:visited {
 	--surface-4: var(--surface-4-light);
 	--background: var(--background-light);
 	--border: var(--border-light);
+	.post a {
+		color: var(--text-1-light);
+	}
 }
 
 html,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -82,10 +82,6 @@
 		text-transform: capitalize;
 	}
 
-	a {
-		color: black;
-	}
-
 	@media (min-width: 768px) {
 		.articles-section {
 			display: flex;


### PR DESCRIPTION
I have updated the article titles to appear in white when the page is in dark mode. This change ensures better visibility and accessibility for users.

### Changes Made:
Adjusted the CSS for article titles to use white colour in dark mode.

### Additional Notes:
Titles appeared white in dark mode when page viewed locally, but black when viewed on [https://secure-git.guide/](url) so it was tricky to identify the cause. If the issue persists, please let me know.